### PR TITLE
fix(auto-config): fixing gpg path and error handling

### DIFF
--- a/auto-config/gpg.go
+++ b/auto-config/gpg.go
@@ -3,9 +3,12 @@ package auto_config
 import (
 	"fmt"
 	strs "git_extensions/shared/strings"
+	"log"
 	"os/exec"
 	"regexp"
 )
+
+const defaultGpgPath = "gpg"
 
 type GpgKey struct {
 	Name  string
@@ -55,11 +58,13 @@ func getGpgExecPath() (string, error) {
 	cmd := exec.Command("git", "config", "gpg.program")
 	output, err := cmd.Output()
 	if err != nil {
-		return "", err
+		log.Printf("error reading command: git config gpg.program = %v", err)
+		log.Printf("fallbacking to gpg as default path")
+		return defaultGpgPath, nil
 	}
 	cleanOutput := strs.TrimExecOutput(output)
 	if cleanOutput == "" {
-		return "gpg", nil
+		return defaultGpgPath, nil
 	}
 	return cleanOutput, nil
 }

--- a/shared/errors/errors.go
+++ b/shared/errors/errors.go
@@ -2,12 +2,11 @@ package errors
 
 import (
 	"fmt"
-	"os"
+	"log"
 )
 
 func HandleError(err error) {
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		log.Fatalf(fmt.Sprintf("Error: %s", err))
 	}
 }


### PR DESCRIPTION
# What

- Fixing error handling to display error formated with fatalf
- Fallbacking gpg path if cmd.Output returns an error